### PR TITLE
Update RatchetTransportProvider.php

### DIFF
--- a/src/RatchetTransportProvider.php
+++ b/src/RatchetTransportProvider.php
@@ -41,17 +41,17 @@ class RatchetTransportProvider extends AbstractRouterTransportProvider implement
     /**
      * @var \Ratchet\Server\IoServer
      */
-    private $server;
+    protected $server;
 
     /**
      * @var \SplObjectStorage
      */
-    private $sessions;
+    protected $sessions;
 
     /**
      * @var WsServer
      */
-    private $ws;
+    protected $ws;
 
     /**
      * Constructor


### PR DESCRIPTION
Enable overriding of `handleRouterStart` without having to duplicate the entire class. See: voryx/Thruway#333